### PR TITLE
Added Cube Approach

### DIFF
--- a/Slipgate/src/org/usfirst/frc/team263/robot/Constants.java
+++ b/Slipgate/src/org/usfirst/frc/team263/robot/Constants.java
@@ -15,8 +15,8 @@ public class Constants {
 	final static double kDriveRKd = 0.000;
 	final static double kDriveRKf = 0.00;
 	final static double kDriveRStaticFr = 0.1;
-	final static double kDriveREpsilon = 1;
-	final static double kCubeSeekSpeed = 0.2;
+	final static double kDriveREpsilon = 2;
+	final static double kCubeSeekSpeed = 0.3;
 	final static int kDriveAccel = 1000;
 	final static int kDriveCruiseVelocity = 5000;
 	final static int kDriveError = 100;

--- a/Slipgate/src/org/usfirst/frc/team263/robot/SWDrive.java
+++ b/Slipgate/src/org/usfirst/frc/team263/robot/SWDrive.java
@@ -152,8 +152,17 @@ public class SWDrive {
 								Constants.kDriveRKf, mNavX.getYaw() + Limelight.getTx());
 					}
 					PidController.updateSP(mNavX.getYaw() + Limelight.getTx());
-					double leftOutput = -PidController.getPidOutput();
-					double rightOutput = PidController.getPidOutput();
+					
+					double leftOutput = 0;
+					double rightOutput = 0;
+					
+					if (PidController.withinEpsilon() && Limelight.getTa() < 25) {
+						leftOutput = Constants.kCubeSeekSpeed;
+						rightOutput = Constants.kCubeSeekSpeed;
+					} else {
+						leftOutput = -PidController.getPidOutput();
+						rightOutput = PidController.getPidOutput();
+					}
 
 					double[] output = { leftOutput, rightOutput };
 					normalize(output);
@@ -318,7 +327,8 @@ public class SWDrive {
 		 *         otherwise.
 		 */
 		public static boolean withinEpsilon() {
-			return error <= Constants.kDriveREpsilon;
+			error = rotationalError(SWDrive.getInstance().mNavX.getYaw(), setPoint);
+			return Math.abs(error) <= Constants.kDriveREpsilon;
 		}
 
 		/**


### PR DESCRIPTION
Now have CubeSeeking mode approach cube after rotational PID is within acceptable error. Right now it drives until the cube is 25% of the total screen. In the future this will be utilizing ty and some trig. For now the area approach worked because of the way the camera was mounted, though.